### PR TITLE
Fix needsReview calculation to use collected responses

### DIFF
--- a/index.html
+++ b/index.html
@@ -2881,7 +2881,11 @@ async function submitAnswers(e) {
     explanation: '',
     autoScore: itemScore,
     scoreConfidence: itemScore > 0 ? 'High' : 'Low',
-    needsReview: itemScore === 0 && response.length > 10,
+    // Flag for manual review if no points were awarded but at least one response
+    // contains more than 10 characters. This helps catch potentially valid
+    // answers that our heuristic auto-scorer missed.
+    needsReview: itemScore === 0 &&
+                 Object.values(itemResult.responses).some(r => r.length > 10),
     scoringNotes: `Auto-scored: ${itemScore}`,
     finalScore: itemScore,
     duration: Math.round((Date.now() - state.itemStartTime) / 1000),


### PR DESCRIPTION
## Summary
- compute `needsReview` flag using collected responses in `submitAnswers`

## Testing
- `npm test` (fails: could not read package.json)
- `node -e "const itemScore=0; const itemResult={responses:{a:'long answer text',b:'short'}}; console.log(itemScore===0 && Object.values(itemResult.responses).some(r=>r.length>10));"`


------
https://chatgpt.com/codex/tasks/task_e_68a4df3a0548832686c940f1d50bade5