### PR TITLE
Support skipping recordings without zero scores

### DIFF
--- a/api/wiat.gs
+++ b/api/wiat.gs
@@ -182,9 +182,12 @@ function handleItemCompleted(ss, data) {
   }
 
   const autoScore = data.autoScore !== undefined && data.autoScore !== '' ? Number(data.autoScore) : '';
-  const finalScore = data.finalScore !== undefined && data.finalScore !== ''
-    ? Number(data.finalScore)
-    : (data.autoScore !== undefined && data.autoScore !== '' ? Number(data.autoScore) : 0);
+  const skipScore = String(data.skipScore).toLowerCase() === 'true';
+  const finalScore = skipScore
+    ? ''
+    : (data.finalScore !== undefined && data.finalScore !== ''
+        ? Number(data.finalScore)
+        : (data.autoScore !== undefined && data.autoScore !== '' ? Number(data.autoScore) : 0));
   const needsReview = String(data.needsReview).toLowerCase() === 'true';
 
   if (targetRow > 0) {
@@ -220,12 +223,15 @@ function handleItemCompleted(ss, data) {
   }
 
   const progressSheet = getOrCreateSheet(ss, 'Item_Progress', ['Timestamp','Initials','Item','Event','Details']);
+  const detail = skipScore
+    ? 'Recording skipped'
+    : `Score: ${autoScore}, Confidence: ${data.scoreConfidence}, Review: ${needsReview ? 'YES' : 'NO'}`;
   progressSheet.appendRow([
     new Date(),
     idKey,
     data.itemNumber,
     'Completed',
-    `Score: ${autoScore}, Confidence: ${data.scoreConfidence}, Review: ${needsReview ? 'YES' : 'NO'}`
+    detail
   ]);
 
   updateSessionTotals(ss, idKey, Number(finalScore) || 0, Number(data.consecutiveZeros) || 0);

--- a/index.html
+++ b/index.html
@@ -3222,20 +3222,21 @@ function handleStopRecording() {
   const durText = (document.getElementById('recording-timer').textContent || '00:00').trim();
   const durSec = durText.split(':').reduce((m, s) => m * 60 + (+s || 0), 0);
 
-    gsPost('item_completed', {
-  initials: state.initials,
-  itemNumber: trial.item,
-  endTime: new Date().toISOString(),
-  duration: durSec,
-  response: '[read-aloud]',
-  explanation: '',
-  autoScore: '',
-  scoreConfidence: '',
-  needsReview: false,
-  scoringNotes: 'read-aloud',
-  finalScore: '',
-  itemType: 'read-aloud'
-});
+  gsPost('item_completed', {
+    initials: state.initials,
+    itemNumber: trial.item,
+    endTime: new Date().toISOString(),
+    duration: durSec,
+    response: '[read-aloud]',
+    explanation: '',
+    autoScore: '',
+    scoreConfidence: '',
+    needsReview: false,
+    scoringNotes: 'read-aloud',
+    finalScore: '',
+    consecutiveZeros: state.consecutiveZeros,
+    itemType: 'read-aloud'
+  });
 
 
   goNextOrFinish();
@@ -3268,6 +3269,8 @@ function handleSkipRecording() {
     needsReview: false,
     scoringNotes: 'read-aloud skipped by user',
     finalScore: '',
+    consecutiveZeros: state.consecutiveZeros,
+    skipScore: true,
     itemType: 'read-aloud'
   });
 


### PR DESCRIPTION
## Summary
- Preserve consecutive zero count when stopping a recording
- Allow skipping recordings without assigning a score
- Log skipped recordings as such in session data

## Testing
- ⚠️ `node --check api/wiat.gs` (failed: Unknown file extension ".gs")
- ✅ `npx --yes htmlhint index.html`


------
https://chatgpt.com/codex/tasks/task_e_68af6331959c8326af222282d5e2e9c7